### PR TITLE
Remove todo from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,3 @@
 I am in the middle of a rewrite of http://undeadly.org for the OpenBSD
 project.  They have existing data that needs to be used.  There is much to be
 done, but it lets you see stories created with the old version.
-
-One known thing on the todo list is to write a todo list.


### PR DESCRIPTION
I was pointed to this repo via [Pull Request Club](https://pullrequest.club/), and while I was orienting myself, I've noticed that there's now a TODO file in the repo, so perhaps the README don't need to state that it still has to be written.

This PR removes that line. Hope it helps, but feel free to point me towards better opportunites for contribution :)